### PR TITLE
[ Annesa ] Like/Unlike Reviews

### DIFF
--- a/soundcrate/src/app/api/review/likeReview/[reviewId]/route.js
+++ b/soundcrate/src/app/api/review/likeReview/[reviewId]/route.js
@@ -1,0 +1,57 @@
+import { connectMongoDB } from '@/lib/mongodb';
+import Review from '@/lib/models/review';
+// import User from '@/lib/models/user';
+import { NextResponse } from 'next/server';
+
+export async function POST(req, { params }){
+  try {
+    const review_id = params.reviewId;
+    const { user_id, action } = await req.json(); // TODO: retrieve user id from headers instead
+
+    await connectMongoDB();
+
+    var res = null;
+
+    let action_obj = {};
+    switch(action) {
+      case 'like':
+        action_obj = { $addToSet: { likes: user_id } };
+        break;
+      case 'unlike':
+        action_obj = { $pull: { likes: user_id } };action_obj = { $pull: { likes: user_id } }
+        break;
+      default:
+        return NextResponse.json(
+          { message: 'Missing "action" field' },
+          { status: 400 }
+        )
+    }
+
+    await Review.findOneAndUpdate(
+      { _id: review_id },
+      { ...action_obj },
+      { new: true }
+    ).then((doc) => {
+      res = NextResponse.json(
+        { body: 
+          {
+            like_count: (doc.likes).length,
+            is_liked: (doc.likes).includes(user_id)
+          }
+        }, 
+        { status: 200 }
+      )
+    })
+    .catch((error) => {
+      throw error;
+    });
+
+  } catch (error) {
+    res = NextResponse.json(
+      { message: "Internal Server Error: " + error },
+      { status: 500 }
+    )
+  } finally {
+    return res;
+  }
+}

--- a/soundcrate/src/app/api/review/likeReview/[reviewId]/route.js
+++ b/soundcrate/src/app/api/review/likeReview/[reviewId]/route.js
@@ -1,6 +1,5 @@
 import { connectMongoDB } from '@/lib/mongodb';
 import Review from '@/lib/models/review';
-// import User from '@/lib/models/user';
 import { NextResponse } from 'next/server';
 
 export async function POST(req, { params }){
@@ -18,7 +17,7 @@ export async function POST(req, { params }){
         action_obj = { $addToSet: { likes: user_id } };
         break;
       case 'unlike':
-        action_obj = { $pull: { likes: user_id } };action_obj = { $pull: { likes: user_id } }
+        action_obj = { $pull: { likes: user_id } };
         break;
       default:
         return NextResponse.json(

--- a/soundcrate/src/app/song/[song_id]/page.js
+++ b/soundcrate/src/app/song/[song_id]/page.js
@@ -117,6 +117,7 @@ export default function SongPage({ params }) {
         song_artist={song_data.artist}
         image={review.user.imageUrl}
         detail_type={'user'}
+        likes={review.likes}
       />
     ))
   }

--- a/soundcrate/src/app/user/[username]/profile/page.js
+++ b/soundcrate/src/app/user/[username]/profile/page.js
@@ -102,6 +102,7 @@ export default function UserProfilePage({ params }) {
           song_artist={song_obj?.artists[0]?.name}
           image={song_obj?.album?.images[1]?.url}
           detail_type={'album'}
+          likes={review.likes}
         />
       )}
     ))

--- a/soundcrate/src/app/user/[username]/profile/reviews/page.js
+++ b/soundcrate/src/app/user/[username]/profile/reviews/page.js
@@ -64,6 +64,7 @@ export default function ListsPage({ params }) {
           song_artist={song_obj?.artists[0]?.name}
           image={song_obj?.album?.images[1]?.url}
           detail_type={'album'}
+          likes={review.likes}
         />
       )}
     ))

--- a/soundcrate/src/app/user/[username]/song/[song_id]/page.js
+++ b/soundcrate/src/app/user/[username]/song/[song_id]/page.js
@@ -122,6 +122,7 @@ export default function SongReviewPage({ params }) {
         song_artist={song_data.artist}
         image={review.user.imageUrl}
         detail_type={'user'}
+        likes={review.likes}
       />
     ))
   }
@@ -143,13 +144,16 @@ export default function SongReviewPage({ params }) {
           {render_header()}
           
           {/* details for most recent review */}
-          <section className="flex flex-col gap-3">
-            {latest_review?.text}
-            <div className="flex flex-row gap-2">
-              <LikeButton review_id={latest_review?._id} show_like_count={false} />
-              <p className="opacity-60 text-sm">{latest_review?.likes.length} {latest_review?.likes.length == 1 ? 'like' : 'likes' }</p>
-            </div>
-          </section>
+          {latest_review &&
+            <section className="flex flex-col gap-3">
+              {latest_review.text}
+              <LikeButton 
+                review_id={latest_review._id}
+                likes={latest_review.likes}
+                compact={false}
+              />
+            </section>
+          }
 
           {/* album link */}
           {/* <Link href={`/user/${username}/album/${latest_review?.albumId}`}>

--- a/soundcrate/src/components/LikeButton.js
+++ b/soundcrate/src/components/LikeButton.js
@@ -1,36 +1,71 @@
 'use client';
 
-import { get_user, is_review_liked, get_review_likes } from '/utils';
 import { Heart } from '@phosphor-icons/react';
 import { useState } from 'react';
 
-export default function LikeButton({ review_id, size=20, show_like_count=true }) {
+export default function LikeButton({ review_id, likes=[], compact=true, size=20 }) {
 
-  const user_id = 1; // mock data, will retrieve this from headers
+  const user_id = '664690bb36aa3aa3e8c8d240'; // mock data, will retrieve this from headers
 
-  // get initial like count to instantiate likeCount state
-  const review_likes = get_review_likes(review_id);
-  const initial_like_count = Boolean(review_likes) == false ? 0 : review_likes.length;
+  const [ isLiked, setIsLiked ] = useState(likes.includes(user_id));
+  const [ likeCount, setLikeCount ] = useState(likes.length);
 
-  const [ isLiked, setIsLiked ] = useState(is_review_liked(user_id, review_id));
-  const [ likeCount, setLikeCount ] = useState(initial_like_count);
-
+  // styling for heart icon depending on isLiked state
   const weight = isLiked ? 'fill' : 'bold';
   const classes = isLiked ? 'text-red opacity-80' : 'opacity-40'
 
   const handleClick = (e) => {
-    setIsLiked(!isLiked);
-    setLikeCount(likeCount + (isLiked ? -1 : 1));
+
+    async function toggleLike(review_id) {
+      try {
+        const req_body = {
+          user_id,
+          action: isLiked ? 'unlike' : 'like'
+        }
+
+        const response = await fetch(
+          `/api/review/likeReview/${review_id}`, 
+          { method: 'POST',
+            body: JSON.stringify(req_body)
+          }
+        );
+    
+        const responseData = await response.json();
+
+        if (responseData?.body) {
+          if (responseData.body.like_count != likeCount) {
+            setIsLiked(responseData.body.is_liked);
+            setLikeCount(responseData.body.like_count);
+          } else {
+            throw "Action unsuccessful";
+          };
+        } else {
+          throw responseData.error;
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    toggleLike(review_id);
     e.stopPropagation();
     e.preventDefault();
   }
 
-  return (
-    <div className="flex flex-col items-center gap-1">
-      <button className="flex flex-col items-center gap-1 z-99 padding-3" onClick={handleClick}>
-        <Heart weight={weight} size={size} className={classes}/>
-      </button>
-      {show_like_count ?? <p className="opacity-80">{likeCount?.toString()}</p>}
-    </div>
-  );
+  return (compact 
+      ? <div className="flex flex-col items-center gap-1">
+          <button className="flex flex-col items-center gap-1 z-99 padding-3" onClick={handleClick}>
+            <Heart weight={weight} size={size} className={classes}/>
+          </button>
+          <p className="opacity-80">{likeCount?.toString()}</p>
+        </div>
+
+      : <div className="flex flex-row gap-2">
+          <button className="flex flex-col items-center gap-1 z-99 padding-3" onClick={handleClick}>
+            <Heart weight={weight} size={size} className={classes}/>
+          </button>
+          <p className="opacity-60 text-sm">{likeCount?.toString()} {likeCount == 1 ? 'like' : 'likes' }</p>
+        </div>
+  )
+
 }

--- a/soundcrate/src/components/SongReviewCard.js
+++ b/soundcrate/src/components/SongReviewCard.js
@@ -15,7 +15,8 @@ export default function SongReviewCard({
   image='',
   track_number=null,
   show_image=true,
-  detail_type='album'
+  detail_type='album',
+  likes=[]
   }) {
 
   // display either album art + song details OR profile image + username
@@ -78,7 +79,11 @@ export default function SongReviewCard({
         </div>
 
         {/* 2 - like count */}
-        <LikeButton review_id={review_id} />
+        <LikeButton 
+          review_id={review_id}
+          likes={likes}
+          compact={true}
+        />
       </div>
     </Link>
   );

--- a/soundcrate/src/components/SongReviewCard.js
+++ b/soundcrate/src/components/SongReviewCard.js
@@ -1,6 +1,5 @@
 'use client';
 
-import { get_user } from '/utils';
 import Link from 'next/link';
 import { Rating, LikeButton } from '@/components';
 


### PR DESCRIPTION
## Context
- Users need to be able to like and unlike reviews

## Changes
- Created API route `likeReview/[reviewId]` to handle both liking and unliking reviews
- Updated `LikeButton` component for use with the API route
- Updated `LikeButton` instances to match with changes made to the component

## Testing
1. Visit a page that displays song reviews other than the home page or album pages (ex. http://localhost:3000/user/janedoe/profile/reviews)
2. Like and unlike a couple of reviews and confirm that the UI changes appropriately
3. Refresh the page and confirm that the likes/unlikes performed are retained
4. Check MongoDB to confirm that the `likes` array updates accordingly when liking/unliking
     - janedoe's user ID appears in the array after liking a review
     - janedoe's user ID is removed from the array after unliking a review
     - janedoe's user ID only appears up to once in the array after multiple likes and unlikes

## Todo
- Incorporate user_id retrieved from headers instead of hardcoded value (janedoe)
- Only allow logged-in users to call the API (using middleware?) and update frontend to handle this