### PR TITLE
[ Annesa ] Spotify Updates

### DIFF
--- a/soundcrate/src/app/page.js
+++ b/soundcrate/src/app/page.js
@@ -2,24 +2,23 @@
 
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
-import { get_random_songs, get_songs } from '../lib/spotify';
+import { get_new_releases, get_songs } from '../lib/spotify';
 import { AlbumCard, SongReviewCard } from '@/components';
 import './home.css';
 import {useSession} from "next-auth/react";
 
 export default function Home() {
   const { data: session } = useSession();
-  const [ exploreSongs, setExploreSongs ] = useState(null);
+  const [ newReleases, setNewReleases ] = useState(null);
   const [ reviews, setReviews ] = useState([]);
   const [ songData, setSongData ] = useState(null);
 
-  // TODO: update to use request headers
 
   // fetch song data from spotify api for explore section
   useEffect(() => {
     async function fetchNewReleases() {
-      const random_songs = await get_random_songs();
-      setExploreSongs(random_songs);
+      const new_releases = await get_new_releases();
+      setNewReleases(new_releases?.items);
     }
     
     fetchNewReleases();
@@ -65,16 +64,16 @@ export default function Home() {
     get_song_data();
   }, [reviews]);
 
-  const render_explore_song_cards = () => {
-    return exploreSongs?.map((song) =>
+  const render_new_release_cards = () => {
+    return newReleases && newReleases.map((album) =>
       <AlbumCard 
-        key={`song-card-${song.id}`}
-        album_id={song.id}
-        name={song.name}
-        artist_name={song.album.artists[0]?.name}
+        key={`album-card-${album.id}`}
+        album_id={album.id}
+        name={album.name}
+        artist_name={album.artists[0]?.name}
         size={20}
-        album_art={song.album.images[1]?.url}
-        href={'/song/'+song.id} />
+        album_art={album.images[0]?.url}
+        href={'/album/'+album.id} />
     );
   }
 
@@ -119,11 +118,11 @@ export default function Home() {
         )}
       </section>
       
-      {/* explore */}
+      {/* new releases */}
       <section className="flex flex-col gap-3 mb-6 w-full">
-        <h2>Explore</h2>
+        <h2>New Releases</h2>
         <div className="columns-5">
-          {render_explore_song_cards()}
+          {render_new_release_cards()}
         </div>
       </section>
 

--- a/soundcrate/src/lib/spotify.js
+++ b/soundcrate/src/lib/spotify.js
@@ -18,15 +18,18 @@ const authorize = async () => {
 
   // attempt to retrieve from session storage first
   var access_token = window.sessionStorage.getItem('spotify-access');
+  var access_token_exp = window.sessionStorage.getItem('spotify-access-exp');
 
   // if none in storage, generate and save a new access token
-  if ((!access_token) || access_token == null || access_token == undefined) {
+  if ((!access_token) || (access_token_exp < Date.now())) {
     try {
+      // getch new spotify access token
       request.post(auth_options, function(error, response, body) {
         if (!error && response.statusCode === 200) {
           // set newly retrieved access token
           access_token = body.access_token;
           window.sessionStorage.setItem('spotify-access', access_token);
+          window.sessionStorage.setItem('spotify-access-exp', Date.now() + body.expires_in * 1000 )
         } else {
           console.log(error);
         }

--- a/soundcrate/src/lib/spotify.js
+++ b/soundcrate/src/lib/spotify.js
@@ -138,3 +138,21 @@ export const get_random_songs = async () => {
     console.log(error);
   }
 };
+
+export const get_new_releases = async () => {
+  const access_token = await authorize();
+
+  try {
+    const response = await axios.get('https://api.spotify.com/v1/browse/new-releases', {
+      headers: {
+        'Authorization': `Bearer ${access_token}`
+      },
+      params: {
+        limit: 5
+      }
+    });
+    return response.data.albums;
+  } catch (error) {
+    console.log(error);
+  }
+};


### PR DESCRIPTION
## Changes
- Updated so that the spotify access token refreshes automatically
- Fixed bug where explore section of home page was not populating by replacing it back with "New Releases" (The specific reccommendations endpoint we were using prior keeps returns with a 429 error)

## Testing
- Visit the home page and confirm that the top explore page now populates with albums
- No need to test this during the review, but the the site should always be able to grab data from the spotify api without having to clear the session storage.

## Images
<img width="1701" alt="image" src="https://github.com/SoundCrate/scfront/assets/93303711/7b730331-1b25-42fa-ac25-42dd4bf87640">

## Todo
- Update security
- Did not update it to use the middleware feature in interest of focusing on other features